### PR TITLE
Scaling a parent is practical, but it currently leads to a crash.

### DIFF
--- a/crates/shared_vehicle/src/vehicle_spawner/bulldozer.rs
+++ b/crates/shared_vehicle/src/vehicle_spawner/bulldozer.rs
@@ -26,6 +26,14 @@ pub fn spawn_bulldozer<'a>(
         chassis_dimensions.y,
         chassis_dimensions.z,
     );
+
+    let parent = commands
+        .spawn((
+            Name::new("bulldozer scaler"),
+            //            Transform::from_scale(Vec3::splat(5f32)),
+            Transform::from_scale(Vec3::splat(1.2f32)),
+        ))
+        .id();
     let mut entity = commands.spawn((
         Name::new("bulldozer"),
         VehicleType::Bulldozer,
@@ -42,6 +50,7 @@ pub fn spawn_bulldozer<'a>(
         }),
         RigidBody::Dynamic,
     ));
+    entity.set_parent(parent);
     // bulldozer front, to push rocks.
     entity.with_child((
         Name::new("bulldozer front"),
@@ -71,6 +80,5 @@ pub fn spawn_bulldozer<'a>(
             )
             .with_scale(Vec3::new(0.8, 0.8, 0.5)),
     ));
-
     entity
 }


### PR DESCRIPTION
on `cargo run --release sandbox`:

```
thread 'Compute Task Pool (14)' panicked at /home/tb/.cargo/registry/src/index.crates.io-1949cf8c6b5b557f/rapier3d-0.23.0/src/geometry/broad_phase_multi_sap/sap_axis.rs:55:13:
proxy.aabb.mins 125530790000 (in Aabb { mins: [125530790000.0, 88610020000.0, 18415034000.0], maxs: [125530790000.0, 88610020000.0, 18415034000.0] }) <= max_bound 125530780000
note: run with `RUST_BACKTRACE=1` environment variable to display a backtrace
Encountered a panic in system `bevy_rapier3d::plugin::systems::step_simulation<()>`!
Encountered a panic in system `bevy_app::main_schedule::Main::run_main`!
```


When printing rigidbody positions, after some steps I've got:
```
    translation: [
        125530790000.0,
        88610020000.0,
        18419239000.0,
    ],
```

which creates unsupported point keys and assertions fail.

Now why does the rigidbody ends up in this position ? :thinking: 

Found the reproduction :tada:, using `force_update_from_transform_changes: true` leads to the crash.

I could reproduce with the following:

<details><summary>Details</summary>
<p>

```rs
use bevy::prelude::*;
use bevy_rapier3d::prelude::*;

fn main() {
    let mut app = App::new();
    app.add_plugins((
        DefaultPlugins,
        bevy_rapier3d::prelude::RapierPhysicsPlugin::<NoUserData>::default(),
    ));
    app.add_systems(Startup, (init_rapier_configuration,));
    app.add_systems(PostStartup, setup);
    app.run();
}

pub fn init_rapier_configuration(
    mut config: Query<&mut RapierConfiguration, With<DefaultRapierContext>>,
) {
    let mut config = config.single_mut();
    *config = RapierConfiguration {
        force_update_from_transform_changes: true,
        ..RapierConfiguration::new(1f32)
    };
}

pub fn setup(mut commands: Commands) {
    let parent = commands
        .spawn(Transform::from_scale(Vec3::splat(3f32)))
        .id();
    let mut entity = commands.spawn((
        Transform::default(),
        Collider::cuboid(1f32, 1f32, 1f32),
        RigidBody::Dynamic,
    ));
    entity.set_parent(parent);
}
```

</p>
</details> 